### PR TITLE
chore: move typescript from peerDependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,9 @@
     "docs:dev": "pnpm -C packages/docs dev",
     "docs:build": "pnpm -C packages/docs build"
   },
-  "peerDependencies": {
-    "typescript": "^5.7.2"
-  },
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "typescript": "^5.7.2",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5"
   }


### PR DESCRIPTION
This moves typescript from peerDependencies to devDependencies to avoid unmet peer warnings in consumer projects.
No runtime behavior changes.